### PR TITLE
cron payments service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ libraryDependencies ++=
       "org.slf4j" % "slf4j-nop" % "1.6.4",
       "org.quartz-scheduler" % "quartz" % "2.3.2",
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
-      "com.outr" %% "hasher" % "1.2.2"
+      "com.outr" %% "hasher" % "1.2.2",
+      "org.quartz-scheduler" % "quartz" % "2.3.2"
     )
 
 scalacOptions ++= Seq(

--- a/src/main/protobuf/daily_reward_paid.proto
+++ b/src/main/protobuf/daily_reward_paid.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package uberpopug.proto;
+
+import "model.proto";
+
+message DailyRewardPaidV1 {
+  string transaction_id = 1;
+  string user_id = 2;
+  int64 debit = 3;
+  int64 credit = 4;
+  int64 cat = 5;
+}

--- a/src/main/protobuf/task_streaming.proto
+++ b/src/main/protobuf/task_streaming.proto
@@ -10,3 +10,11 @@ message TaskStreamingV1 {
   string assignee_id = 3;
   int64 at = 4;
 }
+
+message TaskStreamingV2 {
+  string public_id = 1;
+  string name = 2;
+  string assignee_id = 3;
+  int64 at = 4;
+  string jira_id = 5;
+}

--- a/src/main/scala/accounting/PaymentScheduler.scala
+++ b/src/main/scala/accounting/PaymentScheduler.scala
@@ -1,0 +1,113 @@
+package accounting
+
+import accounting.model.events.DailyRewardPaid
+import accounting.model.{Transaction, User}
+import cats.effect.IO
+import doobie.Transactor
+import doobie._
+import doobie.implicits._
+import cats.syntax.either._
+import utils.KafkaEventProducer
+import cats.syntax.traverse._
+import org.quartz.CronExpression
+
+import java.util.Date
+import scala.concurrent.duration._
+
+class PaymentScheduler(producer: KafkaEventProducer[DailyRewardPaid]) {
+
+  val cron = new CronExpression("0 0 * * *")
+
+  def start: IO[Unit] = {
+    val now = new Date()
+    val time = cron.getTimeAfter(now)
+    IO.sleep((time.getTime - now.getTime).milliseconds) >> action >> start
+  }
+
+  def action = {
+    val billingCycleT =
+      sql"""
+             select id from billing_cycles where status = open
+           """
+        .query[Int]
+        .to[List]
+        .transact(xa)
+
+    val usersT =
+      sql"""
+           select id, public_id, name, role from users
+         """.query[User].to[List]
+
+    def setProcessing(bcId: Int) =
+      sql"""
+        update billing_cycles set status = processing where id = $bcId
+        """.update.run
+
+    def closeBillingCycleT(bcId: Int) =
+      sql"""
+           update billing_cycles set status = closed where id = $bcId
+         """.update.run
+
+    val createNewBC =
+      sql"""
+           insert into billing_cycles (status) values (open) 
+         """.update.run
+
+    for {
+      bcId <- billingCycleT.map(_.headOption.get)
+      t = for {
+        _ <- setProcessing(bcId)
+        _ <- createNewBC
+      } yield ()
+      _ <- t.transact(xa)
+      users <- usersT.transact(xa)
+      _ <- users.traverse(makePaymentForUser(bcId, _))
+      _ <- closeBillingCycleT(bcId).transact(xa)
+    } yield ()
+
+  }
+
+  def makePaymentForUser(processingBcId: Int, user: User): IO[Unit] = {
+
+    val getBalance =
+      sql"""
+           select sum(debit) as debit, sum(credit) as credit from transactions where
+           user_id = ${user.public_id} and billing_cycle_id = $processingBcId
+         """.query[DailyBalance].to[List].map(_.headOption.get).transact(xa)
+
+    getBalance.flatMap { balance =>
+      val cat = new Date()
+      val t = Transaction(
+        s"Выплата пользователю ${user.public_id} за ${cat.toString}",
+        user.public_id,
+        processingBcId,
+        debit = Math.max(0, balance.credit - balance.debit),
+        credit = Math.max(0, balance.debit - balance.credit),
+        cat
+      )
+
+      val payT =
+        sql"""insert into transactions (id, name, user_id, billing_cycle_id, debit, credit, cat)
+              values (${t.id}, ${t.name}, ${t.id}, ${t.billing_cycle_id},
+              ${t.debit}, ${t.credit}, $cat)
+           """.update.run.transact(xa).void
+
+      for {
+        _ <- payT
+        _ <- producer.send(
+          List(DailyRewardPaid(t.id, user.public_id, t.debit, t.credit, cat))
+        )
+        // Payment system call
+      } yield ()
+    }
+  }
+
+  private lazy val xa = Transactor.fromDriverManager[IO](
+    "org.postgresql.Driver",
+    s"jdbc:postgresql:$dbName",
+    "postgres",
+    "pass"
+  )
+
+  case class DailyBalance(debit: Int, credit: Int)
+}

--- a/src/main/scala/accounting/TaskStreamingEventConsumer.scala
+++ b/src/main/scala/accounting/TaskStreamingEventConsumer.scala
@@ -2,17 +2,17 @@ package accounting
 
 import cats.effect.IO
 import tasks.model.events.TaskStreaming
-import utils.KafkaEventConsumer
+import utils.{KafkaEventConsumer, KafkaVersionedEventConsumer}
 
 class TaskStreamingEventConsumer(trc: TaskRepositoryController[IO])
-    extends KafkaEventConsumer[TaskStreaming](
+    extends KafkaVersionedEventConsumer[TaskStreaming](
       "uberpopug.task-streaming",
       "accounting"
     ) {
 
   override def f: TaskStreaming => IO[Unit] = event =>
     trc
-      .create(event.public_id, event.name, event.assignee_id)
+      .create(event.public_id, event.name, event.jira_id, event.assignee_id)
       .fold(
         _ => IO.unit,
         _ => IO.unit

--- a/src/main/scala/accounting/model/events.scala
+++ b/src/main/scala/accounting/model/events.scala
@@ -1,3 +1,40 @@
 package accounting.model
 
-object events {}
+import java.util.Date
+import java.util.Date
+import io.scalaland.chimney.dsl._
+import uberpopug.proto.daily_reward_paid.DailyRewardPaidV1
+import utils._
+
+object events {
+  case class DailyRewardPaid(
+      transaction_id: String,
+      user_id: String,
+      debit: Long,
+      credit: Long,
+      cat: Date
+  )
+
+  object DailyRewardPaid {
+    implicit val be: BinaryEncoder[DailyRewardPaid] =
+      new BinaryEncoder[DailyRewardPaid] {
+        override def encode: DailyRewardPaid => Array[Byte] = ta =>
+          ta.into[DailyRewardPaidV1]
+            .withFieldComputed(_.userId, _.user_id)
+            .withFieldComputed(_.transactionId, _.transaction_id)
+            .transform
+            .toByteArray
+      }
+
+    implicit val bd: BinaryDecoder[DailyRewardPaid] =
+      new BinaryDecoder[DailyRewardPaid] {
+        override def decode: Array[Byte] => DailyRewardPaid = ba =>
+          DailyRewardPaidV1
+            .parseFrom(ba)
+            .into[DailyRewardPaid]
+            .withFieldComputed(_.user_id, _.userId)
+            .withFieldComputed(_.transaction_id, _.transactionId)
+            .transform
+      }
+  }
+}

--- a/src/main/scala/accounting/model/package.scala
+++ b/src/main/scala/accounting/model/package.scala
@@ -20,6 +20,7 @@ package object model {
       id: Int,
       public_id: String,
       name: String,
+      jira_id: String,
       assign_fee: Int,
       complete_reward: Int,
       assignee_id: String

--- a/src/main/scala/tasks/model/package.scala
+++ b/src/main/scala/tasks/model/package.scala
@@ -18,6 +18,7 @@ package object model {
   case class Task(
       public_id: String,
       name: String,
+      jira_id: String,
       description: String,
       assignee_id: String,
       created_by_id: String,

--- a/src/main/scala/utils/KafkaVersionedEventConsumer.scala
+++ b/src/main/scala/utils/KafkaVersionedEventConsumer.scala
@@ -1,0 +1,91 @@
+package utils
+
+import cats.effect.IO
+import fs2.Stream
+import fs2.kafka.{
+  AutoOffsetReset,
+  CommittableConsumerRecord,
+  ConsumerSettings,
+  KafkaConsumer
+}
+import utils.KafkaEventConsumer.{ConsumerContext, KafkaRecord}
+
+import scala.concurrent.duration.FiniteDuration
+import KafkaVersionedEventConsumer._
+import scala.concurrent.duration._
+import cats.syntax.either._
+import fs2.kafka.HeaderDeserializer.int
+
+abstract class KafkaVersionedEventConsumer[T: VersionedBinaryDecoder](
+    topic: String,
+    groupId: String
+) {
+
+  def f: T => IO[Unit]
+
+  def start: IO[Unit] =
+    stream.compile.drain
+      .onErrorRestartWithDelay(1.second)
+      .start
+      .void
+
+  private val stream: Stream[IO, Unit] =
+    KafkaConsumer
+      .stream(consumerSettings)
+      .subscribeTo(topic)
+      .records
+      .map { msg =>
+        val kr = msg.asInstanceOf[KafkaRecord]
+        val version = msg.record
+          .headers("version")
+          .flatMap(_.attemptAs[Int].toOption)
+          .getOrElse(1)
+
+        parseRecord(msg.record.value, version)
+          .map(action => ConsumerContext(action, kr))
+          .leftMap(_ => kr)
+      }
+      .evalMap[IO, Unit] {
+        case Left(_) =>
+          IO.raiseError(new Error("consumer failed"))
+
+        case Right(r) =>
+          f(r.event)
+            .handleErrorWith(e =>
+              IO.delay(println(e.fillInStackTrace())) >> IO.raiseError(e)
+            )
+            .map(_ => r.asRight) >> r.kr.offset.commit
+      }
+
+  private lazy val consumerSettings = ConsumerSettings[IO, Unit, Array[Byte]]
+    .withBootstrapServers("localhost:9092")
+    .withGroupId(groupId)
+    .withMaxPollRecords(100)
+    .withMaxPollInterval(1000.millis)
+    .withSessionTimeout(6001.millis)
+    .withMaxPrefetchBatches(54428800)
+    .withAutoOffsetReset(AutoOffsetReset.Earliest)
+    .withEnableAutoCommit(false)
+
+  def parseRecord(bytes: Array[Byte], version: Int): Either[Throwable, T] = {
+    implicitly[VersionedBinaryDecoder[T]]
+      .decode(version, bytes)
+      .asRight
+  }
+
+}
+
+object KafkaVersionedEventConsumer {
+  case class ConsumerContext[T](event: T, kr: KafkaRecord)
+  type KafkaRecord = CommittableConsumerRecord[IO, Any, Array[Byte]]
+
+  implicit class IOExt[T](val io: IO[T]) extends AnyVal {
+
+    def onErrorRestartWithDelay(
+        delay: FiniteDuration
+    ): IO[T] =
+      io.handleErrorWith { _ =>
+        IO.sleep(delay) >> io.onErrorRestartWithDelay(delay)
+      }
+  }
+}

--- a/src/main/scala/utils/VersionedBinaryDecoder.scala
+++ b/src/main/scala/utils/VersionedBinaryDecoder.scala
@@ -1,0 +1,6 @@
+package utils
+
+trait VersionedBinaryDecoder[T] {
+
+  def decode: (Int, Array[Byte]) => T
+}


### PR DESCRIPTION
Доделки по сервису аккаунтинга

Стратегия обработки новой версии стриминга заданий
1. Для всех новых старых заданий `jira_id` пустое, если приходит старое событие без jira_id, тоже делаем его пустым.
Сначала релиз сервиса с консьюмером версий v1, v1, затем релиз нового продьюсера

Стратегия обработки ошибок при выплатах сотрудникам
1. Делаем N попыток достучаться до сервиса оплаты
2. Если сервис оплат не доступен то добавляем в лог транзакций компенсирующую транзакцию с новым `billing_cycle_id`